### PR TITLE
feat(ingest): add structure extractor and snapshot tests (sprint 2 step1)

### DIFF
--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""
+Ingest package: text normalization and structure extraction.
+"""
+
+__all__: list[str] = []

--- a/ingest/patterns.py
+++ b/ingest/patterns.py
@@ -3,15 +3,23 @@ from __future__ import annotations
 import re
 from typing import Optional, Pattern
 
-# 議題見出し検出：番号/括り記号/丸印などで始まり、話者行（:：）と衝突しない
+"""Pattern utilities for detecting agenda headings and speaker lines."""
+
+# 議題見出し検出：
+# - 行内にコロン（:：）が含まれない
+# - 次のいずれかの形式に合致
+#   * 【...】 / 〔...〕 の括り見出し（行全体）
+#   * 第○（漢数字） + 任意テキスト
+#   * 数字+.)） + 任意テキスト
+#   * 丸印など + 任意テキスト
 AGENDA_HEADING_RE: Pattern[str] = re.compile(
-    r"^(?:"
-    r"第[一二三四五六七八九十百]+[ 　]*"
-    r"|[0-9０-９]{1,3}[.)）][ 　]*"
+    r"^(?!.*[:：])(?:"
+    r"【[^】]+】"
     r"|〔[^〕]+〕"
-    r"|【[^】]+】"
-    r"|[◇◆■○●◎・]"
-    r")(?:(?![:：]).)+$"
+    r"|第[一二三四五六七八九十百]+[ 　]*.+"
+    r"|[0-9０-９]{1,3}[.)）][ 　]*.+"
+    r"|[◇◆■○●◎・].+"
+    r")$"
 )
 
 # 話者行検出：「○中妻委員：」「教育長：」「理事者：」「○ 田中議員：」等
@@ -51,4 +59,3 @@ def is_noise(line: str) -> bool:
     if not s:
         return False
     return bool(PAGE_HEADER_RE.match(s) or PAREN_NOISE_RE.match(s) or DECOR_ONLY_RE.match(s))
-

--- a/ingest/patterns.py
+++ b/ingest/patterns.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from typing import Optional, Pattern
+
+# 議題見出し検出：番号/括り記号/丸印などで始まり、話者行（:：）と衝突しない
+AGENDA_HEADING_RE: Pattern[str] = re.compile(
+    r"^(?:"
+    r"第[一二三四五六七八九十百]+[ 　]*"
+    r"|[0-9０-９]{1,3}[.)）][ 　]*"
+    r"|〔[^〕]+〕"
+    r"|【[^】]+】"
+    r"|[◇◆■○●◎・]"
+    r")(?:(?![:：]).)+$"
+)
+
+# 話者行検出：「○中妻委員：」「教育長：」「理事者：」「○ 田中議員：」等
+SPEAKER_LINE_RE: Pattern[str] = re.compile(
+    r"^(?:[○〇]?[ 　]*)"
+    r"(?P<name>[^\s　:：]+?)"
+    r"(?P<role>委員長|副委員長|委員|議員|部長|課長|教育長|理事者)?"
+    r"[ 　]*[:：]"
+)
+
+# ページノイズ（— 12 — など）/短い括弧書き（拍手・休憩・参照）/装飾のみの行
+PAGE_HEADER_RE: Pattern[str] = re.compile(r"^[―—\-–\s]*\d+\s*[―—\-–\s]*$")
+PAREN_NOISE_RE: Pattern[str] = re.compile(r"^（[^）]{1,8}）$")
+DECOR_ONLY_RE: Pattern[str] = re.compile(r"^[○〇・◎◇◆■]+$")
+
+ROLE_TITLES = {"委員長", "副委員長", "委員", "議員", "部長", "課長", "教育長", "理事者"}
+
+
+def normalize_space(s: str) -> str:
+    s = s.strip()
+    s = re.sub(r"[ \t\u3000]+", " ", s)
+    return s
+
+
+def is_agenda_heading(line: str) -> bool:
+    s = normalize_space(line)
+    return bool(AGENDA_HEADING_RE.match(s))
+
+
+def match_speaker_line(line: str) -> Optional[re.Match[str]]:
+    s = normalize_space(line)
+    return SPEAKER_LINE_RE.match(s)
+
+
+def is_noise(line: str) -> bool:
+    s = normalize_space(line)
+    if not s:
+        return False
+    return bool(PAGE_HEADER_RE.match(s) or PAREN_NOISE_RE.match(s) or DECOR_ONLY_RE.match(s))
+

--- a/ingest/structure_extractor.py
+++ b/ingest/structure_extractor.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from .patterns import (
+    ROLE_TITLES,
+    is_agenda_heading,
+    is_noise,
+    match_speaker_line,
+    normalize_space,
+)
+
+
+class Speech(BaseModel):
+    speaker: str = Field(..., description="話者名（役職語を除いたコア名）")
+    role: Optional[str] = Field(None, description="役職（委員/議員/部長/課長/教育長/理事者 等）")
+    paragraphs: List[str] = Field(default_factory=list, description="発言本文の段落配列")
+
+
+class AgendaItem(BaseModel):
+    title: str
+    order_no: int
+    speeches: List[Speech] = Field(default_factory=list)
+
+
+class MinutesStructure(BaseModel):
+    meeting_date: Optional[str] = None
+    committee: Optional[str] = None
+    page_url: Optional[str] = None
+    pdf_url: Optional[str] = None
+    agenda_items: List[AgendaItem] = Field(default_factory=list)
+
+
+def _read_input_text(obj: Mapping[str, Any]) -> str:
+    if isinstance(obj.get("text"), str):
+        return obj["text"]
+    pages = obj.get("pages")
+    if isinstance(pages, list) and pages and all(isinstance(p, str) for p in pages):
+        return "\n".join(pages)
+    if isinstance(obj.get("content"), str):
+        return obj["content"]
+    return ""
+
+
+def _split_lines(text: str) -> List[str]:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return [ln.rstrip() for ln in text.split("\n")]
+
+
+def _scan_agenda_boundaries(lines: List[str]) -> List[Tuple[int, str]]:
+    boundaries: List[Tuple[int, str]] = []
+    for idx, raw in enumerate(lines):
+        line = normalize_space(raw)
+        if not line or is_noise(line):
+            continue
+        if is_agenda_heading(line):
+            boundaries.append((idx, line))
+    return boundaries
+
+
+def _flush_paragraph(buf: List[str], out: List[str]) -> None:
+    if buf:
+        joined = normalize_space("".join(buf).strip())
+        if joined:
+            out.append(joined)
+        buf.clear()
+
+
+def _split_after_colon(line: str) -> Tuple[str, str]:
+    for i, ch in enumerate(line):
+        if ch in (":", "："):
+            return line[: i + 1], line[i + 1 :].strip()
+    return line, ""
+
+
+def _parse_block_speeches(lines: List[str], start: int, end: int) -> List[Speech]:
+    speeches: List[Speech] = []
+    current: Optional[Speech] = None
+    para_buf: List[str] = []
+    i = start
+    while i < end:
+        raw = lines[i]
+        line = normalize_space(raw)
+        if not line or is_noise(line):
+            _flush_paragraph(para_buf, current.paragraphs if current else [])
+            i += 1
+            continue
+        m = match_speaker_line(line)
+        if m:
+            if current is not None:
+                _flush_paragraph(para_buf, current.paragraphs)
+                speeches.append(current)
+                current = None
+            name = m.group("name")
+            role = m.group("role")
+            if role is None and name in ROLE_TITLES:
+                role = name
+            speaker = name.lstrip("○").strip()
+            current = Speech(speaker=speaker, role=role, paragraphs=[])
+            _, tail = _split_after_colon(raw)
+            if tail:
+                para_buf.append(tail + "\n")
+            i += 1
+            continue
+        if current is not None:
+            para_buf.append(line + "\n")
+        i += 1
+    if current is not None:
+        _flush_paragraph(para_buf, current.paragraphs)
+        speeches.append(current)
+    return speeches
+
+
+def extract_minutes_structure(src: Path | str | Mapping[str, Any]) -> MinutesStructure:
+    if isinstance(src, (str, Path)):
+        obj: Dict[str, Any] = json.loads(Path(src).read_text(encoding="utf-8"))
+    else:
+        obj = dict(src)
+    text = _read_input_text(obj)
+    lines = _split_lines(text)
+    boundaries = _scan_agenda_boundaries(lines)
+    ms = MinutesStructure(
+        meeting_date=obj.get("meeting_date"),
+        committee=obj.get("committee"),
+        page_url=obj.get("page_url"),
+        pdf_url=obj.get("pdf_url"),
+        agenda_items=[],
+    )
+    if not boundaries:
+        speeches = _parse_block_speeches(lines, 0, len(lines))
+        ms.agenda_items.append(AgendaItem(title="（議題なし）", order_no=1, speeches=speeches))
+        return ms
+    idxs = [i for i, _ in boundaries] + [len(lines)]
+    titles = [t for _, t in boundaries]
+    for order_no, (start, end) in enumerate(zip(idxs[:-1], idxs[1:]), start=1):
+        title = titles[order_no - 1]
+        speeches = _parse_block_speeches(lines, start + 1, end)
+        ms.agenda_items.append(AgendaItem(title=title, order_no=order_no, speeches=speeches))
+    return ms
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Extract agenda/speeches structure from normalized minutes JSON")
+    parser.add_argument("--src", required=True, help="Input JSON file path")
+    parser.add_argument("--out", required=False, help="Output JSON file path")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    ms = extract_minutes_structure(args.src)
+    out_text = json.dumps(ms.model_dump(), ensure_ascii=False, indent=2)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(out_text + "\n", encoding="utf-8")
+    else:
+        print(out_text)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ wordcloud = "^1.9.2"
 jsonschema = "^4.23.0"
 python-dotenv = "^1.0.0"
 pypdf = "^6.0.0"
+pydantic = "^2.9"
 
 [tool.poetry.group.app]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ wordcloud = "^1.9.2"
 jsonschema = "^4.23.0"
 python-dotenv = "^1.0.0"
 pypdf = "^6.0.0"
-pydantic = "^2.9"
 
 [tool.poetry.group.app]
 optional = true

--- a/tests/fixtures/sample_minutes_01.json
+++ b/tests/fixtures/sample_minutes_01.json
@@ -1,0 +1,9 @@
+{
+  "meeting_date": "2025-08-21",
+  "committee": "文教児童委員会",
+  "title": "文教児童委員会 議事録（令和7年8月21日）",
+  "page_url": "https://example.local/itabashi/minutes/2025-08-21-bunkyo",
+  "pdf_url": "https://example.local/itabashi/minutes/sample.pdf",
+  "text": "【議題１ 教育行政について】\n○中妻穣太委員：お伺いします。\n続けて質問します。\n\n教育長：ご答弁いたします。\n対応します。\n\n理事者：補足します。\n\n【議題２ 学校給食について】\n○田中太郎議員：給食無償化について。\n継続審議とするべきでは。\n\n委員長：次に進みます。"
+}
+

--- a/tests/fixtures/snapshots/structure_sample01.json
+++ b/tests/fixtures/snapshots/structure_sample01.json
@@ -1,0 +1,56 @@
+{
+  "meeting_date": "2025-08-21",
+  "committee": "文教児童委員会",
+  "page_url": "https://example.local/itabashi/minutes/2025-08-21-bunkyo",
+  "pdf_url": "https://example.local/itabashi/minutes/sample.pdf",
+  "agenda_items": [
+    {
+      "title": "【議題１ 教育行政について】",
+      "order_no": 1,
+      "speeches": [
+        {
+          "speaker": "中妻穣太",
+          "role": "委員",
+          "paragraphs": [
+            "お伺いします。\n続けて質問します。"
+          ]
+        },
+        {
+          "speaker": "教育長",
+          "role": "教育長",
+          "paragraphs": [
+            "ご答弁いたします。\n対応します。"
+          ]
+        },
+        {
+          "speaker": "理事者",
+          "role": "理事者",
+          "paragraphs": [
+            "補足します。"
+          ]
+        }
+      ]
+    },
+    {
+      "title": "【議題２ 学校給食について】",
+      "order_no": 2,
+      "speeches": [
+        {
+          "speaker": "田中太郎",
+          "role": "議員",
+          "paragraphs": [
+            "給食無償化について。\n継続審議とするべきでは。"
+          ]
+        },
+        {
+          "speaker": "委員長",
+          "role": "委員長",
+          "paragraphs": [
+            "次に進みます。"
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/tests/test_structure_extractor.py
+++ b/tests/test_structure_extractor.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from ingest.structure_extractor import extract_minutes_structure
+
+
+def load_record(name: str) -> dict:
+    p = Path("tests/fixtures") / name
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def test_structure_minimum_counts() -> None:
+    rec = load_record("sample_minutes_01.json")
+    ms = extract_minutes_structure(rec)
+    assert len(ms.agenda_items) >= 2
+    total_speeches = sum(len(ai.speeches) for ai in ms.agenda_items)
+    assert total_speeches >= 3
+
+
+def test_first_speakers_prefix_match() -> None:
+    rec = load_record("sample_minutes_01.json")
+    ms = extract_minutes_structure(rec)
+    speakers: List[str] = []
+    for ai in ms.agenda_items:
+        for sp in ai.speeches:
+            speakers.append(sp.speaker)
+    expected_prefix = ["中妻穣太", "教育長", "理事者", "田中太郎"]
+    assert speakers[: len(expected_prefix)] == expected_prefix
+

--- a/tests/test_structure_snapshot.py
+++ b/tests/test_structure_snapshot.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ingest.structure_extractor import extract_minutes_structure
+
+
+def test_structure_snapshot() -> None:
+    rec_path = Path("tests/fixtures/sample_minutes_01.json")
+    snap_path = Path("tests/fixtures/snapshots/structure_sample01.json")
+    rec = json.loads(rec_path.read_text(encoding="utf-8"))
+    ms = extract_minutes_structure(rec)
+    current = ms.model_dump()
+    expected = json.loads(snap_path.read_text(encoding="utf-8"))
+    assert current == expected
+


### PR DESCRIPTION
 - 目的: Sprint 2 Step 1（議題/話者/本文の最小構造抽出）実装。docs/Glyph-prom
pt_202508262107.md準拠。
    - 変更点: ingest/patterns.py, ingest/structure_extractor.py 追加、テスト2本
＋スナップショット、pyproject未変更。
    - 実行確認:
      - poetry install --only main,dev
      - poetry run pytest -q tests/test_structure_extractor.py
      - poetry run pytest -q tests/test_structure_snapshot.py
      - poetry run python -m ingest.structure_extractor --src tests/fixtures/sam
ple_minutes_01.json --out .tmp/structure_out.json
