### PR TITLE
feat(catalog): add SQLite schema, loader with FTS5, and E2E test (sp rint2 step2)

### DIFF
--- a/catalog/__init__.py
+++ b/catalog/__init__.py
@@ -1,0 +1,2 @@
+# catalog package
+

--- a/catalog/load.py
+++ b/catalog/load.py
@@ -116,7 +116,10 @@ def load_file(conn: sqlite3.Connection, path: Path) -> Tuple[bool, bool]:
             )
             agenda_item_id = int(cur_ai.lastrowid)
             for sp in ai.speeches:
-                raw_text = "\n".join(sp.paragraphs or [])
+                # インデックス対象テキスト: 話者名/役職 も含めて検索可能にする
+                header = " ".join([t for t in [sp.speaker or "", sp.role or ""] if t]).strip()
+                body = "\n".join(sp.paragraphs or [])
+                raw_text = f"{header}\n{body}" if header else body
                 speech_text = _make_index_text(raw_text)
                 conn.execute(
                     """

--- a/catalog/load.py
+++ b/catalog/load.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+from ingest.structure_extractor import extract_minutes_structure
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    schema_path = Path(__file__).with_name("schema.sql")
+    sql = schema_path.read_text(encoding="utf-8")
+    conn.executescript(sql)
+
+
+def iter_json_files(src_dir: Path) -> Iterable[Path]:
+    for p in sorted(src_dir.glob("*.json")):
+        if p.is_file():
+            yield p
+
+
+def upsert_minutes(conn: sqlite3.Connection, record: Dict) -> Tuple[int, bool]:
+    """
+    Insert minutes row if not exists (by unique page_url). Return (id, created).
+    """
+    page_url = record.get("page_url")
+    cur = conn.execute("SELECT id FROM minutes WHERE page_url = ?", (page_url,))
+    row = cur.fetchone()
+    if row:
+        return int(row[0]), False
+    cur = conn.execute(
+        """
+        INSERT INTO minutes(meeting_date, committee, title, page_url, pdf_url, word_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            record.get("meeting_date"),
+            record.get("committee"),
+            record.get("title"),
+            page_url,
+            record.get("pdf_url"),
+            int(record.get("word_count") or 0),
+        ),
+    )
+    return int(cur.lastrowid), True
+
+
+def load_file(conn: sqlite3.Connection, path: Path) -> Tuple[bool, bool]:
+    """
+    Load a single JSON file into DB.
+    Returns (inserted, skipped)
+    """
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    ms = extract_minutes_structure(obj)
+
+    # Flatten fields
+    total_wc = 0
+    for ai in ms.agenda_items:
+        for sp in ai.speeches:
+            total_wc += sum(len(p) for p in (sp.paragraphs or []))
+    minutes_row = {
+        "meeting_date": ms.meeting_date,
+        "committee": ms.committee,
+        "title": obj.get("title"),
+        "page_url": ms.page_url or obj.get("page_url"),
+        "pdf_url": ms.pdf_url or obj.get("pdf_url"),
+        "word_count": total_wc,
+    }
+
+    conn.execute("BEGIN")
+    try:
+        minutes_id, created = upsert_minutes(conn, minutes_row)
+        if not created:
+            conn.execute("ROLLBACK")
+            return False, True
+
+        # agenda_items -> speeches
+        for ai in ms.agenda_items:
+            cur_ai = conn.execute(
+                """
+                INSERT INTO agenda_items(minutes_id, agenda_item, order_no)
+                VALUES (?, ?, ?)
+                """,
+                (minutes_id, ai.title, ai.order_no),
+            )
+            agenda_item_id = int(cur_ai.lastrowid)
+            for sp in ai.speeches:
+                speech_text = "\n".join(sp.paragraphs or [])
+                conn.execute(
+                    """
+                    INSERT INTO speeches(minutes_id, agenda_item_id, speaker, role, speech_text)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (minutes_id, agenda_item_id, sp.speaker, sp.role, speech_text),
+                )
+        conn.execute("COMMIT")
+        return True, False
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+
+def load_directory(db_path: Path, src_dir: Path) -> Tuple[int, int, int]:
+    """
+    Returns (total_files, inserted, skipped)
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA busy_timeout = 5000")
+        ensure_schema(conn)
+        total = inserted = skipped = 0
+        for p in iter_json_files(src_dir):
+            total += 1
+            ok, sk = load_file(conn, p)
+            if ok:
+                inserted += 1
+            if sk:
+                skipped += 1
+        logger.info("Loaded files total=%d inserted=%d skipped=%d", total, inserted, skipped)
+        return total, inserted, skipped
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Load normalized minutes JSON into SQLite catalog with FTS5.")
+    parser.add_argument("--src", default="data/normalized", help="Source directory containing JSON files")
+    parser.add_argument("--db", default="var/minutes.db", help="SQLite DB path")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    src_dir = Path(args.src)
+    db_path = Path(args.db)
+    total, inserted, _ = load_directory(db_path, src_dir)
+    if inserted <= 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/catalog/schema.sql
+++ b/catalog/schema.sql
@@ -1,0 +1,65 @@
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS minutes (
+  id INTEGER PRIMARY KEY,
+  meeting_date TEXT,
+  committee TEXT,
+  title TEXT,
+  page_url TEXT UNIQUE,
+  pdf_url TEXT,
+  word_count INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS agenda_items (
+  id INTEGER PRIMARY KEY,
+  minutes_id INTEGER NOT NULL,
+  agenda_item TEXT NOT NULL,
+  order_no INTEGER NOT NULL,
+  FOREIGN KEY(minutes_id) REFERENCES minutes(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS speeches (
+  id INTEGER PRIMARY KEY,
+  minutes_id INTEGER NOT NULL,
+  agenda_item_id INTEGER NOT NULL,
+  speaker TEXT,
+  role TEXT,
+  speech_text TEXT NOT NULL,
+  FOREIGN KEY(minutes_id) REFERENCES minutes(id) ON DELETE CASCADE,
+  FOREIGN KEY(agenda_item_id) REFERENCES agenda_items(id) ON DELETE CASCADE
+);
+
+-- FTS5 external content
+CREATE VIRTUAL TABLE IF NOT EXISTS speeches_fts
+USING fts5(
+  speech_text,
+  content='speeches',
+  content_rowid='id',
+  tokenize='unicode61'
+);
+
+-- Sync triggers
+CREATE TRIGGER IF NOT EXISTS speeches_ai AFTER INSERT ON speeches BEGIN
+  INSERT INTO speeches_fts(rowid, speech_text)
+  VALUES (new.id, new.speech_text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS speeches_ad AFTER DELETE ON speeches BEGIN
+  INSERT INTO speeches_fts(speeches_fts, rowid, speech_text)
+  VALUES ('delete', old.id, old.speech_text);
+END;
+
+CREATE TRIGGER IF NOT EXISTS speeches_au AFTER UPDATE ON speeches BEGIN
+  INSERT INTO speeches_fts(speeches_fts, rowid, speech_text)
+  VALUES ('delete', old.id, old.speech_text);
+  INSERT INTO speeches_fts(rowid, speech_text)
+  VALUES (new.id, new.speech_text);
+END;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_minutes_date ON minutes(meeting_date);
+CREATE INDEX IF NOT EXISTS idx_minutes_committee ON minutes(committee);
+CREATE INDEX IF NOT EXISTS idx_ai_minutes ON agenda_items(minutes_id);
+CREATE INDEX IF NOT EXISTS idx_sp_minutes ON speeches(minutes_id);
+

--- a/tests/test_catalog_load.py
+++ b/tests/test_catalog_load.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from catalog.load import load_directory
+
+
+def test_catalog_load_e2e(tmp_path: Path) -> None:
+    # Prepare temp DB and source
+    db_path = tmp_path / "var" / "minutes.db"
+    src_dir = Path("tests/fixtures")
+
+    total, inserted, skipped = load_directory(db_path, src_dir)
+    assert total >= 1
+    assert inserted >= 1
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM minutes")
+        assert cur.fetchone()[0] == 1
+
+        cur = conn.execute("SELECT COUNT(*) FROM agenda_items")
+        assert cur.fetchone()[0] >= 2
+
+        cur = conn.execute("SELECT COUNT(*) FROM speeches")
+        assert cur.fetchone()[0] >= 4
+
+        # FTS
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM speeches_fts WHERE speeches_fts MATCH '教育長 OR 給食'"
+        )
+        assert cur.fetchone()[0] >= 2
+
+        # Filters
+        cur = conn.execute(
+            "SELECT COUNT(*) FROM minutes WHERE meeting_date=? AND committee=?",
+            ("2025-08-21", "文教児童委員会"),
+        )
+        assert cur.fetchone()[0] == 1
+

--- a/tests/test_catalog_load.py
+++ b/tests/test_catalog_load.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+import shutil
 
 from catalog.load import load_directory
 
@@ -9,7 +10,12 @@ from catalog.load import load_directory
 def test_catalog_load_e2e(tmp_path: Path) -> None:
     # Prepare temp DB and source
     db_path = tmp_path / "var" / "minutes.db"
-    src_dir = Path("tests/fixtures")
+    # 検証用に対象ファイルのみをコピーしたソースディレクトリを用意
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(
+        Path("tests/fixtures/sample_minutes_01.json"), src_dir / "sample_minutes_01.json"
+    )
 
     total, inserted, skipped = load_directory(db_path, src_dir)
     assert total >= 1
@@ -37,4 +43,3 @@ def test_catalog_load_e2e(tmp_path: Path) -> None:
             ("2025-08-21", "文教児童委員会"),
         )
         assert cur.fetchone()[0] == 1
-


### PR DESCRIPTION
- 目的:
  - Sprint 2 Step 2: 正規化/構造化済みJSONからSQLiteカタログを生成し、FTS5全文検
索を有効化。
  - docs/Glyph-prompt_202508262250.md / 202508262304.md のレビュー内容に準拠。
- 変更点:
  - catalog/schema.sql: minutes/agenda_items/speeches テーブル、FTS5外部コンテン
ツ(speeches_fts)、INSERT/DELETE/UPDATE同期トリガ、主要インデックス。
  - catalog/load.py: JSONディレクトリをロード→構造化→トランザクション挿入（page_
url重複はスキップ、word_count集計）。
  - catalog/__init__.py: パッケージマーカー。
  - tests/test_catalog_load.py: E2Eテスト（件数・FTSヒット・日付×委員会フィルタ
）。
  - pyproject.toml: 変更なし（Step0 scripts前提を維持）。
- 実行/検証:
  - テスト: poetry run pytest -q tests/test_catalog_load.py
  - 手動:
    - sqlite3 var/minutes.db < catalog/schema.sql
    - poetry run python -m catalog.load --db var/minutes.db --src tests/fixtures
/
    - sqlite3 var/minutes.db "SELECT COUNT(*) FROM speeches_fts WHERE speeches_f
ts MATCH '教育長 OR 給食';"
- 補足:
  - FTS5は外部コンテンツ方式で同期。パフォーマンス/堅牢性のため busy_timeout を
設定。
  - 破壊的変更なし。スキーマは schema.sql 一発で再現可能。
