### PR TITLE
docs(docs): Sprint 3 wrap-up docs and Nightly triage (#41)

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -16,6 +16,24 @@
 
 リリース: `v0.3.0-sprint3`（想定）
 
+## ステータス（2025-09-09 14:33 JST）
+- #34 完了: Verification Cheatsheet (Sprint 3) と README/スクリプトを追加（PR #42）。
+- #22〜#25: Sprint 3 実装に包含（#33/#29/#31/#32 にて実現）。duplicate コメント付きでClose。
+- #41: Nightly failed 2025-09-08（Artifactsに `nightly-logs-YYYY-MM-DD`）。本日時点は監視継続、恒常化時のみ調整。
+
+### Nightly トリアージ手順（Playbook）
+- 状況確認:
+  - `gh run list --workflow Nightly --limit 5`
+  - `gh run download --name "nightly-logs-YYYY-MM-DD"`
+  - `sed -n '1,200p' nightly.out` / `sed -n '1,200p' logs/nightly.log`
+- 典型原因と対処:
+  - 429/5xx/タイムアウト: バックオフ/リトライ上限の緩和、夜間実行（既定）。単発なら再実行で様子見。
+  - HTML構造変化: crawler のセレクタ更新。responsesベースのテスト追加を検討。
+  - I/Oエラー（Artifactsなし）: 権限/パスを確認。`if-no-files-found: error` で検知済み。
+- 再実行/手動検証:
+  - `gh workflow run Nightly --ref main && gh run watch`
+  - ローカル: `bash scripts/nightly.sh`（API不要、Poetry main のみ）
+
 ## 実行環境・依存
 - Python: 3.11 推奨（CIは3.9/3.10/3.11）
 - Poetry: ローカルは `poetry install --only main,dev` でOK（UI/ノート類は不要）

--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ Notes:
 - 概要: 毎晩のクロール→カタログ構築→成果物（`catalog.duckdb` / `index.json` / `documents.ndjson`）をArtifactsへ保存。金曜はRelease（`catalog-YYYYMMDD`）を作成。
 - 実行: GitHub Actions `Nightly`（JST 01:00）。手動実行は `workflow_dispatch`。
 - 成果物: Artifacts保持14日。失敗時はIssue自動起票（ログは `nightly-logs-YYYY-MM-DD`）。
+
+Troubleshoot（Nightly）
+```bash
+# 最近の実行状況を確認（上位5件）
+gh run list --workflow Nightly --limit 5
+
+# 失敗日のログを取得（例: 2025-09-08）
+gh run download --name "nightly-logs-YYYY-MM-DD"
+
+# ログの中身を見る
+ls -l nightly.out logs/nightly.log
+sed -n '1,200p' nightly.out | sed -n '1,80p'
+```
 ## Notes
 - スキーマ互換性を破壊しないこと（meeting_id は出力に含むが検証時は除外投影）。
 - robots.txt を起動時に取得し、許可判定の上でのみクロールします（読込失敗時は警告ログ、can_fetch 例外時は許可扱い）。

--- a/docs/Codex-report_202509091433.md
+++ b/docs/Codex-report_202509091433.md
@@ -1,0 +1,56 @@
+# Codex Report — 2025-09-09 14:33 JST
+
+Scope
+- Sprint 3 最終段階の締め作業（検証ドキュメント整備、Issue棚卸し、Nightly状況確認）。
+
+What I did
+- #34 実施（PR #42）
+  - 追加: `docs/Verification-Cheatsheet_Sprint3.md`（API/UI/MCP/Nightly/抽出テストの横断チェック）
+  - 追加: `scripts/verify_sprint3.sh`（API/MCPのクイックスモーク）
+  - README: Cheatsheet への導線を追記
+- Issue棚卸し
+  - #22→#33, #23→#29, #24→#31, #25→#32 と重複確認のうえ duplicate コメント付きでClose
+- Nightlyの状況確認
+  - #41: `Nightly failed 2025-09-08` がOpen（Artifacts: `nightly-logs-2025-09-08`）
+  - 直近の実行: `gh run list --workflow Nightly --limit 5` で failure を確認
+
+Current Status
+- Sprint 3 の機能（API v0.2 / UI v0.1 / MCP v0.1 / Nightly / 抽出テスト）は整備済み。
+- 未解決は #41 のNightly失敗（単発の可能性）。今夜の実行を監視、連続失敗なら対処。
+
+Nightly Triage (Playbook)
+```bash
+# 実行状況
+gh run list --workflow Nightly --limit 5
+
+# 失敗日のログ取得（例）
+gh run download --name "nightly-logs-YYYY-MM-DD"
+sed -n '1,200p' nightly.out
+sed -n '1,200p' logs/nightly.log
+
+# 手動再実行（main）
+gh workflow run Nightly --ref main && gh run watch
+```
+- 典型原因と対応
+  - 429/5xx/timeout: バックオフ/リトライを緩和、単発なら様子見
+  - HTML変化: crawlerセレクタ調整 + responsesテスト追加
+  - Artifacts未生成: パス/権限見直し（`if-no-files-found: error`で検知）
+
+Verification Cheatsheet（Sprint 3）
+- 目的: 5〜10分で横断チェック
+- 代表手順:
+  - DB用意（Nightly or 簡易クロール）
+  - API起動→`/search`（`<em>`/ページング）
+  - UI起動→検索/ページャ/詳細
+  - MCP→`[MCP] ... ready` / JSON-RPCワンライナー
+  - Nightly→手動実行/Artifacts ダウンロード
+  - 抽出回帰→ `pytest -q -k structure_extractor`
+
+Next Steps
+- #41 監視（次のNightly）。連続失敗時はログから対象箇所（crawler/構築/Artifacts）を特定・最小修正。
+- 必要に応じ Docs のトラブルシュート拡充（原因特定後に追記）。
+
+Links
+- PR #42: docs(verify) & scripts & README link
+- Issues: #34 完了、#22/#23/#24/#25 duplicate Close、#41 Open（Nightly）
+


### PR DESCRIPTION
- README: Nightly troubleshoot section (gh run list/download, logs)\n- CODEX: Status summary and Nightly triage playbook\n- Report: docs/Codex-report_202509091433.md (Glyph report)\n\nNo code changes.\n\nRefs: #41