### PR TITLE
docs: minor Sprint 3 docs polish (Glyph 202509091509)

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -121,6 +121,7 @@
 
 ## 参考ファイル
 - README.md（Quick Start / Cheatsheet / Lint&Type）
+ - docs/Verification-Cheatsheet_Sprint3.md（横断チェック）
 - docs/Codex-result_*.md（各Stepの報告）
 - scripts/one_shot_apply.py / scripts/rebuild_catalog.py
 - .github/workflows/*.yml（CI）

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Notes:
 - 概要: 毎晩のクロール→カタログ構築→成果物（`catalog.duckdb` / `index.json` / `documents.ndjson`）をArtifactsへ保存。金曜はRelease（`catalog-YYYYMMDD`）を作成。
 - 実行: GitHub Actions `Nightly`（JST 01:00）。手動実行は `workflow_dispatch`。
 - 成果物: Artifacts保持14日。失敗時はIssue自動起票（ログは `nightly-logs-YYYY-MM-DD`）。
+ - Artifacts 名称（目安）: `catalog-dist-YYYY-MM-DD` / `nightly-logs-YYYY-MM-DD`
 
 Troubleshoot（Nightly）
 ```bash


### PR DESCRIPTION
- README: add Nightly artifact names (catalog-dist-YYYY-MM-DD, nightly-logs-YYYY-MM-DD)\n- CODEX: add link to docs/Verification-Cheatsheet_Sprint3.md under references\n\nNo code changes.